### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/src/txfixclient/message.py
+++ b/src/txfixclient/message.py
@@ -48,8 +48,7 @@ class FixMessage(object):
             chksum = self.calc_checksum()
             if chksum != val:
                 raise Exception(
-                    "Incorrect CheckSum: Actually '%s', Should be '%s'" %
-                    (val, chksum)
+                    "Incorrect CheckSum: Actually '{0!s}', Should be '{1!s}'".format(val, chksum)
                     )
             else:
                 self._data.append((int(id), val))
@@ -111,4 +110,4 @@ class FixMessage(object):
         return self.checksum
 
     def _tag_to_string(self, k, v):
-        return "%s=%s%s" % (k, v, self._delimiter)
+        return "{0!s}={1!s}{2!s}".format(k, v, self._delimiter)

--- a/src/txfixclient/protocol.py
+++ b/src/txfixclient/protocol.py
@@ -78,8 +78,7 @@ class FixTagReceiver(Protocol, _PauseableMixin):
 
     def tagLengthExceeded(self, msg):
         raise Exception(
-            'MAX_TAG_LENGTH %s exceeded: %s' %
-            (self.MAX_TAG_LENGTH, msg)
+            'MAX_TAG_LENGTH {0!s} exceeded: {1!s}'.format(self.MAX_TAG_LENGTH, msg)
         )
 
 
@@ -129,8 +128,7 @@ class FixMessageReceiver(FixTagReceiver):
             self._message.append_tag(int(key), val)
             if self._message.checksum != val:
                 raise Exception(
-                    "Incorrect CheckSum: Recieved '%s', Should be '%s'" %
-                    (val, self._message.checksum)
+                    "Incorrect CheckSum: Recieved '{0!s}', Should be '{1!s}'".format(val, self._message.checksum)
                     )
             else:
                 message = self._message

--- a/src/txfixclient/service.py
+++ b/src/txfixclient/service.py
@@ -60,7 +60,7 @@ class FixClientService(service.Service):
         if os.path.isdir(self.config['statsdir']):
             self.stats_dir = self.config['statsdir']
         else:
-            raise Exception("Error: statsdir not found: '%s'" % self.config['statsdir'])
+            raise Exception("Error: statsdir not found: '{0!s}'".format(self.config['statsdir']))
 
         # stats counters
         self.stats = OrderedDict({
@@ -91,7 +91,7 @@ class FixClientService(service.Service):
         self.ttl_histogram = HdrHistogram(1, 10000000, 3)
         self.msglag_histogram = HdrHistogram(1, 10000000, 3)
 
-        namespace = "stats_%s_%s_depth_%s" % (platform.node(),
+        namespace = "stats_{0!s}_{1!s}_depth_{2!s}".format(platform.node(),
                                         self.SenderCompID,
                                         self.config['market_depth'])
         filename = os.path.join(self.stats_dir,
@@ -126,7 +126,7 @@ class FixClientService(service.Service):
         latency['latency_min'] = ih.get_min_value()
         latency['latency_mean'] = ih.get_mean_value()
         for x in [99.90, 99.00]:
-            latency['latency_%.2f' % x] = ih.get_value_at_percentile(x)
+            latency['latency_{0:.2f}'.format(x)] = ih.get_value_at_percentile(x)
 
         # copy and reset ttl histogram
         th = copy.copy(self.ttl_histogram)
@@ -136,7 +136,7 @@ class FixClientService(service.Service):
         ttl['ttl_min'] = th.get_min_value()
         ttl['ttl_mean'] = th.get_mean_value()
         for x in [99.90, 99.00]:
-            ttl['ttl_%.2f' % x] = th.get_value_at_percentile(x)
+            ttl['ttl_{0:.2f}'.format(x)] = th.get_value_at_percentile(x)
 
         # copy and reset ttl histogram
         #ml = copy.copy(self.msglag_histogram)
@@ -209,7 +209,7 @@ class FixClientService(service.Service):
                        created_at=msg.created_at, recieved_at=msg.recieved_at,
                        delta=delta)
 
-        method = getattr(self, "handle_%s" % msg_type, None)
+        method = getattr(self, "handle_{0!s}".format(msg_type), None)
 
         #try:
         if method is not None:


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:LMAX-Exchange:txfixclient?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:LMAX-Exchange:txfixclient?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
